### PR TITLE
Feat/nrd 569

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow the host, that is used to request the QuantCast `choice.js` script, to be overwritten from config.
 
 ## [2.1.0] - 2019-11-21
 ## [2.1.0-beta.1] - 2019-10-16

--- a/template/quantcast.js
+++ b/template/quantcast.js
@@ -1,7 +1,8 @@
 (function() {
 	var ndmCmpConfig = window.ndmCmpConfig || {};
+	var quantcastConfig = ndmCmpConfig.quantcast || {};
 	var xhttp = new XMLHttpRequest();
-	var host = ndmCmpConfig.host || window.location.hostname;
+	var host = quantcastConfig.host || window.location.hostname;
 	var element = document.createElement('script');
 	var firstScript = document.getElementsByTagName('script')[0];
 	var milliseconds = (new Date).getTime();

--- a/template/quantcast.js
+++ b/template/quantcast.js
@@ -1,6 +1,7 @@
 (function() {
+	var ndmCmpConfig = window.ndmCmpConfig || {};
 	var xhttp = new XMLHttpRequest();
-	var host = window.location.hostname;
+	var host = ndmCmpConfig.host || window.location.hostname;
 	var element = document.createElement('script');
 	var firstScript = document.getElementsByTagName('script')[0];
 	var milliseconds = (new Date).getTime();


### PR DESCRIPTION
By default `window.location.hostname` is used to request the QuantCast `choice.js` script. This change allows the host to be set from config.